### PR TITLE
Fix references to npm package to use scoped version

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,17 +5,17 @@ This library offers a few methods to make it easier to add interactivity to Form
 ## Installation
 
 ### With a bundler
-- `npm install formkeep`, or
-- `yarn add formkeep`
+- `npm install @formkeep/formkeep`, or
+- `yarn add @formkeep/formkeep`
 - Then use in your code with:
   ```javascript
-    const FormKeep = require('formkeep')
+    const FormKeep = require('@formkeep/formkeep')
   ```
 
 ### Without a bundler
 - Add to your HTML header:
   ```html
-    <script src="unpkg.com/formkeep/dist/index.js"></script>
+    <script src="unpkg.com/@formkeep/formkeep"></script>
   ```
 - Use the `FormKeep` global variable:
   ```javascript

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@formkeep/formkeep",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "FormKeep helpers for the browser",
   "main": "./dist/index.js",
   "author": "FormKeep",

--- a/samples/package.json
+++ b/samples/package.json
@@ -11,6 +11,6 @@
     "parcel": "^1.10.3"
   },
   "dependencies": {
-    "@formkeep/formkeep": "^0.0.0"
+    "@formkeep/formkeep": "0.0.1"
   }
 }

--- a/samples/yarn.lock
+++ b/samples/yarn.lock
@@ -629,6 +629,11 @@
     lodash "^4.17.10"
     to-fast-properties "^2.0.0"
 
+"@formkeep/formkeep@0.0.1":
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/@formkeep/formkeep/-/formkeep-0.0.0.tgz#9f5ac88bc37e3770bbefeebbefb8c68bdeb9916d"
+  integrity sha512-1ucNpmN3yPlN3iZ24aDnoBMPvO/+hEZuGcpgPKgE6USjdLk0NEk776GrjmG4mPEPSpu5zXfYIoQIGk6BxxntFg==
+
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"


### PR DESCRIPTION
The README had references to `formkeep` where it should now be `@formkeep/formkeep`