### PR TITLE
Remove export workaround which generates warnings in Gatsby

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ This library offers a few methods to make it easier to add interactivity to Form
   - [Run samples locally](#samples)
   - [Show a success message](#show-a-success-message)
   - [Redirect to a page depending on input](#redirect-to-a-page-depending-on-input)
-  - [Redirect to a page depending on input](#redirect-to-a-page-depending-on-input)
   - [Customize the Thanks page depending on input](#customize-the-thanks-page-depending-on-input)
   - [Submit the form through AJAX](#submit-the-form-through-ajax)
+  - [Post JSON data to FormKeep](#post-json-data-to-formkeep)
 
 - __[API](#api)__
   - [post](#post)

--- a/index.js
+++ b/index.js
@@ -3,16 +3,4 @@ export { asyncForm } from './src/asyncForm'
 export { thanksForm } from './src/thanksForm'
 export { redirectForm } from './src/redirectForm'
 
-import { post } from './src/post'
-import { asyncForm } from './src/asyncForm'
-import { thanksForm } from './src/thanksForm'
-import { redirectForm } from './src/redirectForm'
-
 import './src/autoloadAsyncForms'
-
-export default {
-  post,
-  asyncForm,
-  thanksForm,
-  redirectForm
-}


### PR DESCRIPTION
I honestly don't remember why this was here, but the samples work fine without it, and it generates a warning in Gatsby (because it's forcing all the files to be bundled, which makes sense to be a no-no)