### PR TITLE
Fix autoload always running

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,10 @@ This library offers a few methods to make it easier to add interactivity to Form
 ### Without a bundler
 - Add to your HTML header:
   ```html
+    <!-- For library use: -->
     <script src="unpkg.com/@formkeep/formkeep"></script>
+    <!-- For autoload use: -->
+    <script src="unpkg.com/@formkeep/formkeep/autoload"></script>
   ```
 - Use the `FormKeep` global variable:
   ```javascript
@@ -48,7 +51,7 @@ This library offers a few methods to make it easier to add interactivity to Form
 
 ### Show a success message
 
-1. [Load the script](#without-a-bundler)
+1. [Load the autoload script](#without-a-bundler)
 1. Add a `<form>` with `data-formkeep-id="<YOUR_FORM_IDENTIFIER>"`
 1. Give the `<form>` or any other element an `id="<SOME_UNIQUE_ID>"`
 1. Add a `<template>` with `data-formkeep-success-template=<YOUR_FORM_IDENTIFIER>` and `data-target="#<SOME_UNIQUE_ID>"` _(notice the `#`)_

--- a/autoload.js
+++ b/autoload.js
@@ -1,0 +1,1 @@
+import './src/autoloadAsyncForms'

--- a/index.js
+++ b/index.js
@@ -2,5 +2,3 @@ export { post } from './src/post'
 export { asyncForm } from './src/asyncForm'
 export { thanksForm } from './src/thanksForm'
 export { redirectForm } from './src/redirectForm'
-
-import './src/autoloadAsyncForms'

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "test": "jest",
     "test:debug": "node --inspect node_modules/.bin/jest --runInBand",
-    "build": "parcel build index.js --global FormKeep",
+    "build": "parcel build index.js --global FormKeep autoload.js",
     "prepare": "yarn build"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@formkeep/formkeep",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "FormKeep helpers for the browser",
   "main": "./dist/index.js",
   "author": "FormKeep",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@formkeep/formkeep",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "FormKeep helpers for the browser",
   "main": "./dist/index.js",
   "author": "FormKeep",

--- a/samples/pages/autoload.js
+++ b/samples/pages/autoload.js
@@ -1,0 +1,1 @@
+require('@formkeep/formkeep/autoload')

--- a/samples/pages/autoloadAsyncForms.html
+++ b/samples/pages/autoloadAsyncForms.html
@@ -1,6 +1,6 @@
 <html>
   <head>
-    <script src="./formkeep.js"></script>
+    <script src="./autoload.js"></script>
   </head>
   <body>
     <form data-formkeep-id="149105c7eb4a">


### PR DESCRIPTION
This causes trouble with static site builders that might run the library in a node environment, where the document isn't available.